### PR TITLE
Replace HTTP links with HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ Soundfonts Available
 ----
 
 - Fluid-Soundfont
-    - Generated from [FluidR3_GM.sf2](http://www.musescore.org/download/fluid-soundfont.tar.gz) (141 MB uncompressed)
-    - Released under [Creative Commons Attribution 3.0 license](http://creativecommons.org/licenses/by/3.0/us/)
-    - Instrument names as .json file [here](http://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/names.json)
-    - URL prefix to fetch files: http://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/
+    - Generated from [FluidR3_GM.sf2](https://www.musescore.org/download/fluid-soundfont.tar.gz) (141 MB uncompressed)
+    - Released under [Creative Commons Attribution 3.0 license](https://creativecommons.org/licenses/by/3.0/us/)
+    - Instrument names as .json file [here](https://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/names.json)
+    - URL prefix to fetch files: https://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/
 
 - Musyng Kite Soundfont
-    - Generated from [Musyng Kite.sfpack](http://www.synthfont.com/punbb/viewtopic.php?id=167) (1 GB uncompressed)
+    - Generated from [Musyng Kite.sfpack](https://www.synthfont.com/punbb/viewtopic.php?id=167) (1 GB uncompressed)
     - Released under [Creative Commons Attribution Share-Alike 3.0 license](https://creativecommons.org/licenses/by-sa/3.0/)
-    - Instrument names as .json file [here](http://gleitz.github.io/midi-js-soundfonts/MusyngKite/names.json)
-    - URL prefix to fetch files: http://gleitz.github.io/midi-js-soundfonts/MusyngKite/
+    - Instrument names as .json file [here](https://gleitz.github.io/midi-js-soundfonts/MusyngKite/names.json)
+    - URL prefix to fetch files: https://gleitz.github.io/midi-js-soundfonts/MusyngKite/
 
 
 Notes
 -----
 
 - Fork of MIDI.js with parallized soundfont generation [available here](https://github.com/gleitz/MIDI.js).
-- You can fetch Soundfont files directly from this repository, so you can access them directly from a browser. Use the prefix URL following by the instrument name. For example: http://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/marimba-mp3.js
+- You can fetch Soundfont files directly from this repository, so you can access them directly from a browser. Use the prefix URL following by the instrument name. For example: https://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/marimba-mp3.js


### PR DESCRIPTION
When I'm using a link from `URL prefix to fetch files` it doesn't work on the HTTPS page because it's trying to load files in an insecure manner from HTTP. To prevent this type of problem for anyone using this repo it's better to replace HTTP links with HTTPS (and they all work the same).

Most links outside of `gleitz.github.io` are dead and I didn't change anything in them except for http->https as I couldn't find the new destinations for mentioned files.